### PR TITLE
Bump version to update npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "node-usb-native",
   "displayName": "serialport and usb-detection native node",
   "description": "precompile cross-platform serialport and usb-detection dll libraries and load libraries according to platform",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "lib/index.js",
   "repository": "https://github.com/VSChina/serialport.node",
   "dependencies": {


### PR DESCRIPTION
Bad "Zone.Identifier" files made it into the lib/native folder and the published 0.0.17 version. Unpublished 0.0.17 but cannot reuse that version number as npm does not allow publishing the same version number after unpublishing. Bumping version to update npm, no other changes, the bad files were removed in previous checkin but after the npm publish.